### PR TITLE
feat: add dotenv-vault CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
         with:
           command: test
 
+      - name: Build CLI
+        run: |
+          cargo build --bin dotenv-vault --features=cli
+
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,14 @@ jobs:
           command: test
           args: --no-run
 
+      - name: Build CLI
+        run: |
+          cargo build --bin dotenv-vault --features=cli
+
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-
-      - name: Build CLI
-        run: |
-          cargo build --bin dotenv-vault --features=cli
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [stable, beta, nightly, 1.65.0]
+        rust: [stable, beta, nightly, 1.73.0]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [stable, beta, nightly, 1.64.0]
+        rust: [stable, beta, nightly, 1.65.0]
     steps:
       - uses: actions/checkout@v3
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "rust-analyzer.cargo.features": "all",
+    "rust-analyzer.cargo.allTargets": true,
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,19 @@ license = "MIT"
 edition = "2021"
 rust-version = "1.64.0"
 
+[[bin]]
+name = "dotenv-vault"
+required-features = ["cli"]
+
+[lib]
+
+[features]
+default = []
+cli = ["dep:argh"]
+
 [dependencies]
 aes-gcm = "0.10.2"
+argh = { version = "0.1.12", optional = true }
 base64 = "0.21.2"
 dotenvy = "0.15.7"
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,12 @@ cli = ["dep:argh"]
 [dependencies]
 aes-gcm = "0.10.2"
 argh = { version = "0.1.12", optional = true }
-base64 = "0.21.2"
+base64 = "0.22.1"
 dotenvy = "0.15.7"
 hex = "0.4.3"
 url = "2.4.0"
 
 [dev-dependencies]
-serial_test = "2.0.0"
+serial_test = "3.1.1"
 tempfile = "3.7.0"
 assert_cmd = { version = "2.0.14", features = ["color-auto"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["dotenv", "env", "environment", "settings", "vault"]
 categories = ["config"]
 license = "MIT"
 edition = "2021"
-rust-version = "1.64.0"
+rust-version = "1.65.0"
 
 [[bin]]
 name = "dotenv-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ url = "2.4.0"
 [dev-dependencies]
 serial_test = "2.0.0"
 tempfile = "3.7.0"
+assert_cmd = { version = "2.0.14", features = ["color-auto"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["dotenv", "env", "environment", "settings", "vault"]
 categories = ["config"]
 license = "MIT"
 edition = "2021"
-rust-version = "1.65.0"
+rust-version = "1.73.0"
 
 [[bin]]
 name = "dotenv-vault"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ The extended standard lets you load encrypted secrets from your `.env.vault` fil
 * [FAQ](#faq)
 * [Changelog](./CHANGELOG.md)
 
+## Install CLI
+
+The dotenv-vault CLI allows loading the `.env.vault` file and run the given program with the environment variables set.
+
+```shell
+cargo install dotenv-vault --features cli
+```
+
+## Usage CLI
+
+```shell
+dotenv-vault run -- some_program arg1 arg2
+```
+
 ## Install
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ cargo install dotenv-vault --features cli
 dotenv-vault run -- some_program arg1 arg2
 ```
 
+or run at a different working directory that contains the `.env.vault` and override existing environment variables:
+
+```shell
+dotenv-vault run --cwd ./some_folder --override -- some_program arg1 arg2
+```
+
 ## Install
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/dotenv-vault.svg)](https://crates.io/crates/dotenv-vault)
 [![msrv
-1.64.0](https://img.shields.io/badge/msrv-1.64.0-dea584.svg?logo=rust)](https://github.com/rust-lang/rust/releases/tag/1.64.0)
+1.65.0](https://img.shields.io/badge/msrv-1.65.0-dea584.svg?logo=rust)](https://github.com/rust-lang/rust/releases/tag/1.65.0)
 [![ci](https://github.com/Minebomber/dotenv-vault-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/Minebomber/dotenv-vault-rs/actions/workflows/ci.yml)
 [![docs](https://img.shields.io/docsrs/dotenv-vault?logo=docs.rs)](https://docs.rs/dotenv-vault/)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/dotenv-vault.svg)](https://crates.io/crates/dotenv-vault)
 [![msrv
-1.65.0](https://img.shields.io/badge/msrv-1.65.0-dea584.svg?logo=rust)](https://github.com/rust-lang/rust/releases/tag/1.65.0)
+1.73.0](https://img.shields.io/badge/msrv-1.73.0-dea584.svg?logo=rust)](https://github.com/rust-lang/rust/releases/tag/1.73.0)
 [![ci](https://github.com/Minebomber/dotenv-vault-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/Minebomber/dotenv-vault-rs/actions/workflows/ci.yml)
 [![docs](https://img.shields.io/docsrs/dotenv-vault?logo=docs.rs)](https://docs.rs/dotenv-vault/)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ mod tests {
 
         let tmp = tempdir().unwrap();
         let vault_path = tmp.path().join(".env.vault");
-        let mut vault = File::create(&vault_path).unwrap();
+        let mut vault = File::create(vault_path).unwrap();
         vault
             .write_all("DOTENV_VAULT_PRODUCTION=\"s7NYXa809k/bVSPwIAmJhPJmEGTtU0hG58hOZy7I0ix6y5HP8LsHBsZCYC/gw5DDFy5DgOcyd18R\"".as_bytes())
             .unwrap();
@@ -101,7 +101,7 @@ mod tests {
     fn dotenv_fallback_to_env() {
         let tmp = tempdir().unwrap();
         let env_path = tmp.path().join(".env");
-        let mut env = File::create(&env_path).unwrap();
+        let mut env = File::create(env_path).unwrap();
         env.write_all("TESTKEY=\"from .env\"".as_bytes()).unwrap();
         env.sync_all().unwrap();
 
@@ -127,7 +127,7 @@ mod tests {
 
         let tmp = tempdir().unwrap();
         let vault_path = tmp.path().join(".env.vault");
-        let mut vault = File::create(&vault_path).unwrap();
+        let mut vault = File::create(vault_path).unwrap();
         vault
             .write_all("DOTENV_VAULT_PRODUCTION=\"s7NYXa809k/bVSPwIAmJhPJmEGTtU0hG58hOZy7I0ix6y5HP8LsHBsZCYC/gw5DDFy5DgOcyd18R\"".as_bytes())
             .unwrap();
@@ -156,7 +156,7 @@ mod tests {
     fn dotenv_override_fallback_to_env() {
         let tmp = tempdir().unwrap();
         let env_path = tmp.path().join(".env");
-        let mut env = File::create(&env_path).unwrap();
+        let mut env = File::create(env_path).unwrap();
         env.write_all("TESTKEY=\"from .env\"".as_bytes()).unwrap();
         env.sync_all().unwrap();
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -7,7 +7,7 @@ macro_rules! log_fn {
         where
             T: Display,
         {
-            println!(
+            eprintln!(
                 "[dotenv-vault@{}][{}] {}",
                 env!("CARGO_PKG_VERSION"),
                 $level,

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ fn main() {
             };
 
             // Run the specified program with the specified arguments
-            let output = Command::new(run_opts.program)
+            let output = Command::new(&run_opts.program)
                 .args(run_opts.program_args)
                 .envs(env::vars())
                 .stdin(Stdio::inherit())
@@ -87,7 +87,7 @@ fn main() {
                 .stderr(Stdio::inherit())
                 .output()
                 .unwrap_or_else(|err| {
-                    eprintln!("Failed to execute program: {}", err);
+                    eprintln!("Failed to execute program {}: {}", run_opts.program, err);
                     exit(CLIError::ProgramExecution as i32);
                 });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,94 @@
+use argh::FromArgs;
+use dotenv_vault::dotenv;
+use std::env;
+use std::process::{exit, Command};
+
+#[derive(FromArgs, PartialEq, Debug)]
+/// The CLI program to load the .env.vault file and run the specified program with the specified arguments.
+///
+/// You have to set the DOTENV_KEY environment variable before calling dotenv-vault.
+///
+/// Example:
+/// dotenv-vault run -- my_program arg1 arg2
+struct Opts {
+    #[argh(subcommand)]
+    commands: Commands,
+
+    #[argh(switch, long = "override")]
+    /// whether to override the existing environment variables
+    override_: bool,
+
+    #[argh(positional)]
+    /// the separator
+    separator: String,
+
+    #[argh(positional)]
+    /// the program to run
+    program: String,
+
+    #[argh(positional)]
+    /// the arguments to pass to the program
+    program_args: Vec<String>,
+}
+
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand)]
+enum Commands {
+    Run(Run),
+}
+
+#[derive(FromArgs, PartialEq, Debug)]
+/// Load the .env.vault file and run the specified program with the specified arguments.
+#[argh(subcommand, name = "run")]
+struct Run {}
+
+#[derive(Debug)]
+#[repr(i32)]
+enum CLIError {
+    Separator,
+    EnvLoad,
+    EnvOverrideLoad,
+    ProgramExecution,
+}
+
+fn main() {
+    let opts = argh::from_env::<Opts>();
+
+    // Check if the separator is correct
+    if opts.separator != "--" {
+        eprintln!("Invalid separator: {}. Expected --", opts.separator);
+        exit(CLIError::Separator as i32);
+    }
+
+    // Load the .env.vault file
+    if opts.override_ {
+        dotenv().unwrap_or_else(|err| {
+            eprintln!("{}", err);
+            exit(CLIError::EnvOverrideLoad as i32);
+        });
+    } else {
+        dotenv_vault::dotenv().unwrap_or_else(|err| {
+            eprintln!("{}", err);
+            exit(CLIError::EnvLoad as i32);
+        });
+    };
+
+    // Run the specified program with the specified arguments
+    let output = Command::new(opts.program)
+        .args(opts.program_args)
+        .envs(env::vars())
+        .output()
+        .unwrap_or_else(|err| {
+            eprintln!("Failed to execute program: {}", err);
+            exit(CLIError::ProgramExecution as i32);
+        });
+
+    if !output.status.success() {
+        exit(
+            output
+                .status
+                .code()
+                .unwrap_or(CLIError::ProgramExecution as i32),
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use argh::FromArgs;
 use std::env;
-use std::process::{exit, Command};
+use std::process::{exit, Command, Stdio};
 
 #[derive(FromArgs, PartialEq, Debug)]
 /// The CLI program to load the .env.vault file and run the specified program with the specified arguments.
@@ -67,6 +67,9 @@ fn main() {
             let output = Command::new(run_opts.program)
                 .args(run_opts.program_args)
                 .envs(env::vars())
+                .stdin(Stdio::inherit())
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
                 .output()
                 .unwrap_or_else(|err| {
                     eprintln!("Failed to execute program: {}", err);

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ fn main() {
             let current_cwd = env::current_dir().unwrap();
 
             if let Some(given_cwd) = run_opts.cwd {
-                env::set_current_dir(&given_cwd).unwrap_or_else(|err| {
+                env::set_current_dir(given_cwd).unwrap_or_else(|err| {
                     eprintln!("Failed to change the current working directory: {}", err);
                     exit(CLIError::CwdChange as i32);
                 });

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -31,15 +31,35 @@ fn dotenv_vault_cli() {
         assert_eq!(String::from_utf8(output.stdout).unwrap(), "zeta\n");
     }
 
+    env::set_current_dir(&cwd).unwrap();
+
     {
         env::set_var("ALPHA", "beta");
 
-        // Run the CLI program with dotenv-vault run --override -- <program> <arguments>
+        // override the existing environment variables and specify the current working directory
         let mut cmd = Command::cargo_bin("dotenv-vault").unwrap();
         if cfg!(windows) {
-            cmd.args(["run", "--override", "--", "cmd", "/C", "echo %ALPHA%"]);
+            cmd.args([
+                "run",
+                "--cwd",
+                tmp.path().to_string_lossy().as_ref(),
+                "--override",
+                "--",
+                "cmd",
+                "/C",
+                "echo %ALPHA%",
+            ]);
         } else {
-            cmd.args(["run", "--override", "--", "bash", "-c", "printenv ALPHA"]);
+            cmd.args([
+                "run",
+                "--cwd",
+                tmp.path().to_string_lossy().as_ref(),
+                "--override",
+                "--",
+                "bash",
+                "-c",
+                "printenv ALPHA",
+            ]);
         }
 
         cmd.assert().success();

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,0 +1,53 @@
+use assert_cmd::Command;
+use std::{env, fs::File, io::prelude::*};
+use tempfile::tempdir;
+
+#[test]
+fn dotenv_vault_cli() {
+    env::set_var("DOTENV_KEY", "dotenv://:key_ddcaa26504cd70a6fef9801901c3981538563a1767c297cb8416e8a38c62fe00@dotenv.local/vault/.env.vault?environment=production");
+
+    let tmp = tempdir().unwrap();
+    let vault_path = tmp.path().join(".env.vault");
+    let mut vault = File::create(&vault_path).unwrap();
+    vault
+            .write_all("DOTENV_VAULT_PRODUCTION=\"s7NYXa809k/bVSPwIAmJhPJmEGTtU0hG58hOZy7I0ix6y5HP8LsHBsZCYC/gw5DDFy5DgOcyd18R\"".as_bytes())
+            .unwrap();
+    vault.sync_all().unwrap();
+
+    let cwd = env::current_dir().unwrap();
+    env::set_current_dir(&tmp).unwrap();
+
+    {
+        // Run the CLI program with dotenv-vault run -- <program> <arguments>
+        let mut cmd = Command::cargo_bin("dotenv-vault").unwrap();
+        if cfg!(windows) {
+            cmd.args(["run", "--", "cmd", "/C", "echo %ALPHA%"]);
+        } else {
+            cmd.args(["run", "--", "bash", "-c", "printenv ALPHA"]);
+        }
+
+        cmd.assert().success();
+        let output = cmd.output().unwrap();
+        assert_eq!(String::from_utf8(output.stdout).unwrap(), "zeta\n");
+    }
+
+    {
+        env::set_var("ALPHA", "beta");
+
+        // Run the CLI program with dotenv-vault run --override -- <program> <arguments>
+        let mut cmd = Command::cargo_bin("dotenv-vault").unwrap();
+        if cfg!(windows) {
+            cmd.args(["run", "--override", "--", "cmd", "/C", "echo %ALPHA%"]);
+        } else {
+            cmd.args(["run", "--override", "--", "bash", "-c", "printenv ALPHA"]);
+        }
+
+        cmd.assert().success();
+        let output = cmd.output().unwrap();
+        assert_eq!(String::from_utf8(output.stdout).unwrap(), "zeta\n");
+    }
+
+    tmp.close().unwrap();
+    env::remove_var("DOTENV_KEY");
+    env::set_current_dir(cwd).unwrap();
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -8,7 +8,7 @@ fn dotenv_vault_cli() {
 
     let tmp = tempdir().unwrap();
     let vault_path = tmp.path().join(".env.vault");
-    let mut vault = File::create(&vault_path).unwrap();
+    let mut vault = File::create(vault_path).unwrap();
     vault
             .write_all("DOTENV_VAULT_PRODUCTION=\"s7NYXa809k/bVSPwIAmJhPJmEGTtU0hG58hOZy7I0ix6y5HP8LsHBsZCYC/gw5DDFy5DgOcyd18R\"".as_bytes())
             .unwrap();


### PR DESCRIPTION
This adds a CLI that allows using dotenv-vault functionality for any shell program. 

Fixes #1 


The dotenv-vault CLI allows loading the `.env.vault` file and run the given program with the environment variables set.

```shell
cargo install dotenv-vault --features cli
```

```shell
dotenv-vault run -- some_program arg1 arg2
```
